### PR TITLE
remove kubectx dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,10 @@ up:
 	echo "- op: replace\n  path: /spec/template/spec/volumes/0/hostPath/path\n  value: $(PWD)/cnc" > kubernetes/tilt/cnc.yaml
 	test -f secret/redis.json || echo '{"host": "redis.cnc-forge"}' > secret/redis.json
 	test -f secret/github.json || echo '{"user": "changeme", "token": "*******"}' > secret/github.json
-	kubectx docker-desktop
-	tilt --port $(TILT_PORT) up
+	tilt --port $(TILT_PORT) up --context docker-desktop
 
 down:
-	kubectx docker-desktop
-	tilt down
+	tilt down --context docker-desktop
 
 tag:
 	-git tag -a "v$(VERSION)" -m "Version $(VERSION)"

--- a/Tiltfile
+++ b/Tiltfile
@@ -6,12 +6,12 @@ k8s_yaml(kustomize('kubernetes/tilt'))
 
 local_resource(
     name='secret',
-    cmd='kubectx docker-desktop && kubectl -n cnc-forge create secret generic secret --from-file secret/ --dry-run=client -o yaml | kubectl apply -f -'
+    cmd='kubectl --context docker-desktop -n cnc-forge create secret generic secret --from-file secret/ --dry-run=client -o yaml | kubectl --context docker-desktop apply -f -'
 )
 
 local_resource(
     name='forge', deps=["forge/"],
-    cmd='kubectx docker-desktop && kubectl -n cnc-forge create configmap forge --from-file forge/ --dry-run=client -o yaml | kubectl apply -f -'
+    cmd='kubectl --context docker-desktop -n cnc-forge create configmap forge --from-file forge/ --dry-run=client -o yaml | kubectl --context docker-desktop apply -f -'
 )
 
 k8s_resource('redis', port_forwards=['26770:5678'])


### PR DESCRIPTION
Removes the need for the external app `kubectx` and relies on the kubeconfig flag `--context docker-desktop` instead. 

@gaf3 